### PR TITLE
#11 バージョン取得用エンドポイントの実装

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,5 +2,4 @@
 show_missing = true
 omit =
     __init__.py
-    src/responses/*
     src/main.py

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -1,0 +1,16 @@
+from pydantic_settings import BaseSettings
+
+
+class Settings(BaseSettings):
+    """
+    アプリ設定
+
+    Attributes
+        - MAJOR_VERSION (int): メジャーバージョン
+        - MINOR_VERSION (int): マイナーバージョン
+        - PATCH_VERSION (int): パッチバージョン
+    """
+
+    MAJOR_VERSION: int = 0
+    MINOR_VERSION: int = 0
+    PATCH_VERSION: int = 0

--- a/src/responses/version.py
+++ b/src/responses/version.py
@@ -1,0 +1,12 @@
+from src.responses.base import ResponseBase
+
+
+class VersionResponse(ResponseBase):
+    """
+    バージョン取得用エンドポイントのレスポンスクラス
+
+    Attributes:
+        - version (str): バージョン
+    """
+
+    version: str

--- a/src/routers/__init__.py
+++ b/src/routers/__init__.py
@@ -1,6 +1,8 @@
 from fastapi import APIRouter
 
 from src.routers.health import router as health_router
+from src.routers.version import router as version_router
 
 router = APIRouter(prefix="/api")
 router.include_router(router=health_router)
+router.include_router(router=version_router)

--- a/src/routers/version.py
+++ b/src/routers/version.py
@@ -1,0 +1,19 @@
+from fastapi import APIRouter
+
+from src.config.settings import Settings
+from src.responses.version import VersionResponse
+
+router = APIRouter()
+
+
+@router.get(path="/version")
+def get_version() -> VersionResponse:
+    """
+    サーバアプリのバージョンを返す
+    """
+
+    settings = Settings()
+
+    return VersionResponse(
+        version=f"{settings.MAJOR_VERSION}.{settings.MINOR_VERSION}.{settings.PATCH_VERSION}"
+    )

--- a/tests/routers/test_version.py
+++ b/tests/routers/test_version.py
@@ -1,0 +1,19 @@
+from fastapi.testclient import TestClient
+from pytest_mock import MockFixture
+
+from src.config.settings import Settings
+from src.main import app
+
+client = TestClient(app=app)
+
+
+def test_get_version(mocker: MockFixture) -> None:
+    mocker.patch(
+        "src.routers.version.Settings",
+        return_value=Settings(MAJOR_VERSION=1, MINOR_VERSION=0, PATCH_VERSION=0),
+    )
+
+    response = client.get(url="/api/version")
+
+    assert response.status_code == 200
+    assert response.json() == {"version": "1.0.0"}


### PR DESCRIPTION
## 概要

バージョン取得用エンドポイントを実装しました。

## ISSUEへのリンク

Resolves #11 

## 対応内容

バージョン取得用エンドポイントを実装しました。

- path: /api/version
- method: GET

また、上記に対するテストを実装しました。

## 動作確認

/api/versionに対してリクエストを行い、現バージョンである"0.0.0"が返ってくることを確認しました。
また、テストを実行し、カバレージが100%であることを確認しました。

## リリースに関する情報

## その他
