### PR TITLE
Settingsで.envから環境変数を読み込むように変更

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,9 +124,7 @@ celerybeat.pid
 # Environments
 .env
 .venv
-env/
 venv/
-ENV/
 env.bak/
 venv.bak/
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -1477,4 +1477,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "41160a4698107c016637b690f6b2361e53212e159baab684b06c2232f03e53b1"
+content-hash = "4217806a49567d04fe37387e1f4a70e70b16539463f4d0e3da39f9588804f6ca"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.12"
+python-dotenv = "^1.0.1"
 pydantic = "^2.8.2"
 pydantic-settings = "^2.3.4"
 pyyaml = "^6.0.1"

--- a/src/config.py
+++ b/src/config.py
@@ -1,4 +1,4 @@
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
@@ -14,3 +14,5 @@ class Settings(BaseSettings):
     MAJOR_VERSION: int = 0
     MINOR_VERSION: int = 0
     PATCH_VERSION: int = 0
+
+    model_config = SettingsConfigDict(env_file="./env/.env", env_file_encoding="utf-8")

--- a/src/routers/version.py
+++ b/src/routers/version.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 
-from src.config.settings import Settings
+from src.config import Settings
 from src.responses.version import VersionResponse
 
 router = APIRouter()

--- a/tests/routers/test_version.py
+++ b/tests/routers/test_version.py
@@ -1,7 +1,7 @@
 from fastapi.testclient import TestClient
 from pytest_mock import MockFixture
 
-from src.config.settings import Settings
+from src.config import Settings
 from src.main import app
 
 client = TestClient(app=app)


### PR DESCRIPTION
## 概要

Settingsクラスにて、.envから環境変数を読み込むように変更しました。

## ISSUEへのリンク

Resolves #20 

## 対応内容

Settingsクラスにて、.envから環境変数を読み込むように変更しました。
また、src/config/settings.pyからsrc/config.pyへ変更しました。

## 動作確認

テストを実施し、カバレージが100%であることを確認しました。

## リリースに関する情報

## その他
